### PR TITLE
remove macos update phase

### DIFF
--- a/production_manifest.json
+++ b/production_manifest.json
@@ -161,16 +161,6 @@
             "type": "shell"
         },
         {
-            "item": "Update macOS",
-            "version": "",
-            "url": "resources/update-macos.sh",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "ce9ab785e5e6818c47c2371385668000c8b267d1bdc31ecbc28bf7f6a01583b9",
-            "type": "shell"
-        },
-        {
             "item": "Install Zoom",
             "version": "5.8.3.2240",
             "url": "https://zoom.us/client/${version}/Zoom.pkg",


### PR DESCRIPTION
We should move the macos update step either to outside (so the tech can take care of it) - or perhaps make the script smarter when validating whether an update is needed. For now, this step causes a long delay when downloading macos updates that can be up to few gigabytes in size, and when apple servers time out, this breaks the rest of the build.